### PR TITLE
docs: redesign README around an SVG hero and a CLI options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,76 @@
-# git-folder-status
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="100%"
+       alt="git-folder-status: scans a directory tree and reports every Git repo that is not fully synced with its remote. A folder tree tags my-repo as dirty, my-other-repo as ahead 1, tools/scanner as stash 1, notes as no remote, and dotfiles as clean.">
+</p>
 
-[![Tests][tests-badge]][tests-link]
-[![uv][uv-badge]][uv-link]
-[![Ruff][ruff-badge]][ruff-link]
-[![Black][black-badge]][black-link]
-[![codecov][codecov-badge]][codecov-link]
-\
-[![Made Using tsvikas/python-template][template-badge]][template-link]
-[![GitHub Discussion][github-discussions-badge]][github-discussions-link]
-[![PRs Welcome][prs-welcome-badge]][prs-welcome-link]
+<p align="center">
+<a href="https://github.com/tsvikas/git-folder-status/actions/workflows/ci.yml"><img src="https://github.com/tsvikas/git-folder-status/actions/workflows/ci.yml/badge.svg" alt="Tests"></a>
+<a href="https://codecov.io/gh/tsvikas/git-folder-status"><img src="https://codecov.io/gh/tsvikas/git-folder-status/graph/badge.svg" alt="codecov"></a>
+<a href="https://github.com/astral-sh/uv"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json" alt="uv"></a>
+<a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+<a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Black"></a>
+<br>
+<a href="https://github.com/tsvikas/python-template"><img src="https://img.shields.io/badge/%F0%9F%9A%80_Made_Using-tsvikas%2Fpython--template-gold" alt="Made Using tsvikas/python-template"></a>
+<a href="https://github.com/tsvikas/git-folder-status/discussions"><img src="https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github" alt="GitHub Discussion"></a>
+<a href="https://opensource.guide/how-to-contribute/"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
+</p>
 
-## Overview
+## What it looks like
 
-Scans a directory tree and reports Git repositories that aren't fully synced
-with their remote.
+![One command scans every repo under a directory and prints only the ones with unsaved work](assets/screenshot.png)
 
-A day-to-day tool for when you work across multiple projects and want to keep
-everything pushed and backed up. One command instead of running `git status`
-in each repo.
-
-![Screenshot](assets/screenshot.png)
-
-### Why not just `git status`?
-
-`git status` only shows uncommitted changes in the current repo. This tool
-runs across all repos in a directory tree and catches things `git status`
-misses:
-
-- Stash entries
-- Detached HEAD
-- Branches without a remote
-- Branches ahead of or behind remote
-- Tags not on remote, or differing from remote (`--slow`)
-- Non-repo directories containing files
-- Broken symlinks
-- And of course, uncommitted changes and untracked files
-
-Linked worktrees of the same repo are grouped under their main worktree, so
-repo-level state (stash, branches, tags) is reported once instead of repeated
-for every worktree.
+Point it at the folder where you keep your projects.
+It walks the tree, inspects every Git repo it finds, and prints only the ones holding work that is not safely on a remote.
 
 ## Install
-
-Install this tool using pipx (or uv):
 
 ```bash
 pipx install git+https://github.com/tsvikas/git-folder-status.git
 ```
 
-## Usage
+`uv tool install` works the same way.
+Requires Python 3.10 or newer.
 
-Run it with:
+## Use
 
 ```bash
-git-folder-status /path/to/code/directory
+git-folder-status ~/code
 ```
 
-Use `git-folder-status --help` to learn more.
+By default it recurses 3 levels deep and prints a colored report of repos with issues.
+
+| Option                 | Short | Does                                                   |
+| ---------------------- | ----- | ------------------------------------------------------ |
+| `--recurse N`          | `-r`  | Max depth to descend into directories (default 3)      |
+| `--exclude-dir NAME`   | `-d`  | Skip these directories. Repeatable                     |
+| `--format FMT`         | `-f`  | Output as `report`, `yaml`, `json`, or `pprint`        |
+| `--empty`              | `-e`  | Also list repos that have no issues                    |
+| `--all`                | `-a`  | Show extra info for each repo, not just issues         |
+| `--slow`               | `-s`  | Enable expensive checks, currently tag comparison      |
+| `--include-behind`     | `-b`  | Also flag branches that are only behind the remote     |
+| `--external-worktrees` | `-w`  | Analyze worktrees living outside the scanned directory |
+
+Use `--format json` or `--format yaml` to pipe the results into another tool.
+
+## Why not just `git status`?
+
+`git status` covers one repo, and only its working tree.
+This tool covers a whole tree of repos, and catches states that `git status` stays quiet about:
+
+- Uncommitted changes and untracked files
+- Stash entries you forgot about
+- Detached HEAD
+- Branches with no remote at all
+- Branches ahead of or behind their remote
+- Tags missing from the remote, or differing from it (`--slow`)
+- Non-repo directories that still contain files
+- Broken symlinks
+
+Linked worktrees of the same repo are grouped under their main worktree.
+Repo-level state such as stashes, branches, and tags is reported once instead of repeated for every worktree.
 
 ## Contributing
 
-Interested in contributing?
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guideline.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
-[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
-[black-link]: https://github.com/psf/black
-[codecov-badge]: https://codecov.io/gh/tsvikas/git-folder-status/graph/badge.svg
-[codecov-link]: https://codecov.io/gh/tsvikas/git-folder-status
-[github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
-[github-discussions-link]: https://github.com/tsvikas/git-folder-status/discussions
-[prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
-[prs-welcome-link]: https://opensource.guide/how-to-contribute/
-[ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
-[ruff-link]: https://github.com/astral-sh/ruff
-[template-badge]: https://img.shields.io/badge/%F0%9F%9A%80_Made_Using-tsvikas%2Fpython--template-gold
-[template-link]: https://github.com/tsvikas/python-template
-[tests-badge]: https://github.com/tsvikas/git-folder-status/actions/workflows/ci.yml/badge.svg
-[tests-link]: https://github.com/tsvikas/git-folder-status/actions/workflows/ci.yml
-[uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
-[uv-link]: https://github.com/astral-sh/uv
+Licensed under the MIT License.

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="360" viewBox="0 0 1200 360"
+     role="img" aria-labelledby="title desc">
+  <title id="title">git-folder-status</title>
+  <desc id="desc">A folder tree of Git repositories, each tagged with the state that keeps it from being safely pushed: dirty, ahead 1, stash 1, no remote, clean.</desc>
+
+  <rect width="1200" height="360" rx="26" fill="#0d1117"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="358.5" rx="25.25" fill="none" stroke="#21262d" stroke-width="1.5"/>
+
+  <g id="title-block" transform="translate(56 56)">
+    <text x="0" y="8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="12" letter-spacing="2.4" fill="#8b949e">CLI · GIT HYGIENE</text>
+
+    <text x="0" y="64" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="46" font-weight="700" fill="#e6edf3">git-folder-status</text>
+
+    <text x="0" y="110" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+          font-size="19" fill="#c9d1d9">Scans a directory tree and reports every Git repo</text>
+    <text x="0" y="138" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+          font-size="19" fill="#c9d1d9">that is not fully synced with its remote.</text>
+
+    <rect x="0" y="176" width="520" height="48" rx="12" fill="#010409" stroke="#21262d" stroke-width="1.5"/>
+    <text x="18" y="206" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="17" fill="#8b949e">$</text>
+    <text x="38" y="206" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="17" fill="#e6edf3">git-folder-status ~/code</text>
+
+    <text x="0" y="262" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="13" fill="#6e7681">Python 3.10+ · MIT · one command instead of one git status per repo</text>
+  </g>
+
+  <g id="project-proof" transform="translate(672 72)">
+    <text x="0" y="0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="17" fill="#8b949e">~/code</text>
+
+    <path d="M10 14 V 217" fill="none" stroke="#30363d" stroke-width="1.5"/>
+    <path d="M10 41 H 26 M10 85 H 26 M10 129 H 26 M10 173 H 26 M10 217 H 26"
+          fill="none" stroke="#30363d" stroke-width="1.5"/>
+
+    <g id="row-dirty">
+      <text x="36" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="17" fill="#e6edf3">my-repo</text>
+      <rect x="400" y="29" width="60" height="24" rx="9" fill="#f85149" fill-opacity="0.14" stroke="#f85149" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="430" y="46" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="13" fill="#f85149">dirty</text>
+    </g>
+
+    <g id="row-ahead">
+      <text x="36" y="90" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="17" fill="#e6edf3">my-other-repo</text>
+      <rect x="385" y="73" width="75" height="24" rx="9" fill="#d29922" fill-opacity="0.14" stroke="#d29922" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="422.5" y="90" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="13" fill="#d29922">ahead 1</text>
+    </g>
+
+    <g id="row-stash">
+      <text x="36" y="134" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="17" fill="#e6edf3">tools/scanner</text>
+      <rect x="385" y="117" width="75" height="24" rx="9" fill="#d29922" fill-opacity="0.14" stroke="#d29922" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="422.5" y="134" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="13" fill="#d29922">stash 1</text>
+    </g>
+
+    <g id="row-no-remote">
+      <text x="36" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="17" fill="#e6edf3">notes</text>
+      <rect x="370" y="161" width="90" height="24" rx="9" fill="#f85149" fill-opacity="0.14" stroke="#f85149" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="415" y="178" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="13" fill="#f85149">no remote</text>
+    </g>
+
+    <g id="row-clean">
+      <text x="36" y="222" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="17" fill="#6e7681">dotfiles</text>
+      <rect x="400" y="205" width="60" height="24" rx="9" fill="#3fb950" fill-opacity="0.12" stroke="#3fb950" stroke-opacity="0.35" stroke-width="1"/>
+      <text x="430" y="222" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="13" fill="#3fb950">clean</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## What

Full README redesign, plus one new asset.

**`assets/readme/hero.svg`** (4.8 KB, self-contained SVG)

The motif is a folder tree whose nodes carry the real check types (`dirty`, `ahead 1`, `stash 1`, `no remote`, `clean`), so the first screen also answers "what does it catch". Deliberately not a second terminal mockup: `assets/screenshot.png` already fills that role.

It supplies its own dark background and border, so it reads on both GitHub light and dark themes. No scripts, no `foreignObject`, no remote fonts, nothing GitHub's sanitizer strips.

**README**

| Change | Why |
| --- | --- |
| Hero SVG at top | First screen explains the tool without prior knowledge |
| Badges consolidated, centered | Drops the odd `\` line break and the 16-line reference-link footer |
| Screenshot promoted to "What it looks like" | Proof before prose |
| New options table | The CLI has 8 flags and the README only said `--help`. The biggest real content gain |
| "Why not git status?" moved below usage | Differentiation matters after someone can run it |

Net 5 lines shorter.

## Verification

- Every flag, short form, default, and `--format` choice checked against `uv run git-folder-status --help`
- Hero rendered at 1200px and 420px via `rsvg-convert`
- `just format` and `just lint` pass
- `just test` could not run in this environment: `/home/fedora/code_TODOs` is unmounted, so the dangling `TODO.md` symlink breaks pytest collection at the repo root. Pre-existing and unrelated. This change touches no Python.
- `docs/index.md` is standalone and does not include the README, so the MkDocs build is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhEtB5aUkuWaLvYnS5ryaR